### PR TITLE
Fix filename of visible PSF file in psf.py

### DIFF
--- a/src/pandorapsf/psf.py
+++ b/src/pandorapsf/psf.py
@@ -324,7 +324,7 @@ class PSF(object):
 
         if name.lower() in ["vis", "visda", "visible"]:
             p = PSF.from_file(
-                f"{PACKAGEDIR}/data/pandora_vis_hr_20220506.fits",
+                f"{PACKAGEDIR}/data/pandora_vis_20220506.fits",
                 transpose=transpose,
                 extrapolate=True,
                 scale=scale,


### PR DESCRIPTION
The filename was wrong - the downloaded file does not have hr in the name

```
% ls  /Users/tsbarcl2/anaconda3/lib/python3.11/site-packages/pandorapsf/data/pandora_vis_20220506.fits
/Users/tsbarcl2/anaconda3/lib/python3.11/site-packages/pandorapsf/data/pandora_vis_20220506.fits
% ls /Users/tsbarcl2/anaconda3/lib/python3.11/site-packages/pandorapsf/data/pandora_vis_hr_20220506.fits
ls: /Users/tsbarcl2/anaconda3/lib/python3.11/site-packages/pandorapsf/data/pandora_vis_hr_20220506.fits: No such file or directory
```